### PR TITLE
Add support for 4MB  and 8MB flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,5 +94,7 @@ Eine Anpassung ist bei Verwendung der Vorlage in der Regel nicht notwendig.
 | Variante             | System | USB Exchange | Internes Dateisystem |
 | -------------------- | -----: | -----------: | -------------------: |
 | RP2040_EXCHANGE_2MB  |  1 MiB |      256 KiB |          ca. 768 KiB |
+| RP2040_EXCHANGE_4MB  |  1 MiB |      512 KiB |          ca. 2,5 MiB |
+| RP2040_EXCHANGE_8MB  |  1 MiB |      768 KiB |         ca. 6,25 MiB |
 | RP2040_EXCHANGE_16MB |  1 MiB |        1 MiB |           ca. 14 MiB |
 

--- a/platformio.exchange.ini
+++ b/platformio.exchange.ini
@@ -2,19 +2,40 @@
 [RP2040_EXCHANGE]
 build_flags =
   -D USE_BLOCK_DEVICE_INTERFACE
-  -D EXCHANGE_FLASH_OFFSET=0x00100000
-  -D EXCHANGE_FS_SIZE=0x01000000
+  -D EXCHANGE_FLASH_OFFSET=0x00100000 ; 1MB
+  -D EXCHANGE_FS_SIZE=0x01000000 ; 16MB
+
+; ================================= FLASH SIZES =================================
+; The initial 1,048,576 bytes (1MiB) have been preserved to maintain a consistent 
+; flash partitioning and ensure compatibility. This is the minimum size!
+; 
+; On total flash size >1MB, only the file sytem profits from the additional space.
+; Keep in mind that we need at the fs end at least 4096 bytes for EEPROM emulation.
 
 [RP2040_EXCHANGE_16MB]
-extends = RP2040_EXCHANGE, RP2040_16MB
-board_build.filesystem_size = 14675968
+extends = RP2040_EXCHANGE, RP2040_16MB ; 16MiB Flash
+board_build.filesystem_size = 14675968 ; 14 MiB (16MiB - 1MiB (System) - 1MiB (Exchange) - 4KiB (EEPROM))
 build_flags =
   ${RP2040_EXCHANGE.build_flags}
-  -D EXCHANGE_FLASH_SIZE=0x100000
+  -D EXCHANGE_FLASH_SIZE=0x100000 ; 1MiB
+
+[RP2040_EXCHANGE_8MB]
+extends = RP2040_EXCHANGE, RP2040_8MB ; 8MiB Flash
+board_build.filesystem_size = 6532800 ; 6,25MiB (8MiB - 1MiB (System) - 0,75MiB (Exchange) - 4KiB (EEPROM))
+build_flags =
+  ${RP2040_EXCHANGE.build_flags}
+  -D EXCHANGE_FLASH_SIZE=0xC0000 ; 0,75MiB
+
+[RP2040_EXCHANGE_4MB]
+extends = RP2040_EXCHANGE, RP2040_4MB ; 4MiB Flash (in bytes 4
+board_build.filesystem_size = 3141632 ; 2,5MiB (4MiB - 1MiB (System) - 0,5MiB (Exchange) - 4KiB (EEPROM))
+build_flags =
+  ${RP2040_EXCHANGE.build_flags}
+  -D EXCHANGE_FLASH_SIZE=0x80000 ; 0,5MiB
 
 [RP2040_EXCHANGE_2MB]
-extends = RP2040_EXCHANGE, RP2040_2MB
-board_build.filesystem_size = 782336
+extends = RP2040_EXCHANGE, RP2040_2MB ; 2MiB Flash
+board_build.filesystem_size = 782336 ; 0,75MiB (2MiB - 1MiB (System) - 0,25Mib (Exchange) - 4KiB (EEPROM))
 build_flags =
   ${RP2040_EXCHANGE.build_flags}
-  -D EXCHANGE_FLASH_SIZE=0x40000
+  -D EXCHANGE_FLASH_SIZE=0x40000 ; 0,25MiB


### PR DESCRIPTION
To support the Pi Pico2 (rp2350), which has default on-board flash of 4MB
Updated readme and add. come comments with additional Informations. 