### PR TITLE
Add Environment with 2MiB System Memory for 16MB Devices

### DIFF
--- a/platformio.exchange.ini
+++ b/platformio.exchange.ini
@@ -6,6 +6,13 @@ build_flags =
   -D EXCHANGE_FLASH_OFFSET=0x00100000 ; 1MB
   -D EXCHANGE_FS_SIZE=0x01000000 ; 16MB
 
+[RP2040_WITH_SYSTEM_2MB_EXCHANGE]
+build_flags =
+  -D OPENKNX_USB_MSC
+  -D USE_BLOCK_DEVICE_INTERFACE
+  -D EXCHANGE_FLASH_OFFSET=0x00200000 ; 2MB
+  -D EXCHANGE_FS_SIZE=0x01000000 ; 16MB
+
 ; ================================= FLASH SIZES =================================
 ; The initial 1,048,576 bytes (1MiB) have been preserved to maintain a consistent 
 ; flash partitioning and ensure compatibility. This is the minimum size!
@@ -18,6 +25,13 @@ extends = RP2040_EXCHANGE, RP2040_16MB ; 16MiB Flash
 board_build.filesystem_size = 14675968 ; 14 MiB (16MiB - 1MiB (System) - 1MiB (Exchange) - 4KiB (EEPROM))
 build_flags =
   ${RP2040_EXCHANGE.build_flags}
+  -D EXCHANGE_FLASH_SIZE=0x100000 ; 1MiB
+
+[RP2040_WITH_SYSTEM_2MB_EXCHANGE_16MB]
+extends = RP2040_WITH_SYSTEM_2MB_EXCHANGE, RP2040_16MB ; 16MiB Flash
+board_build.filesystem_size = 13627392 ; 13 MiB (16MiB - 2MiB (System) - 1MiB (Exchange) - 4KiB (EEPROM))
+build_flags =
+  ${RP2040_WITH_SYSTEM_2MB_EXCHANGE.build_flags}
   -D EXCHANGE_FLASH_SIZE=0x100000 ; 1MiB
 
 [RP2040_EXCHANGE_8MB]


### PR DESCRIPTION
Alternative zur Standard-Umgebung mit 1MiB für Firmwares mit hohem Speicherbedarf (insbesondere bei DEV-Builds mit aktiven DEBUG-Flags)